### PR TITLE
Enhancement: Unix portability improvements

### DIFF
--- a/src/bq_common/platform/unix_misc.cpp
+++ b/src/bq_common/platform/unix_misc.cpp
@@ -1,0 +1,58 @@
+﻿/*
+ * Copyright (C) 2024 THL A29 Limited, a Tencent company.
+ * BQLOG is licensed under the Apache License, Version 2.0.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+#include "bq_common/platform/platform_misc.h"
+#if BQ_UNIX
+#include <pthread.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <time.h>
+#include <unistd.h>
+namespace bq {
+    namespace platform {
+        // According to test result, benifit from VDSO.
+        //"CLOCK_REALTIME_COARSE clock_gettime"  has higher performance
+        //  than "gettimeofday" and event "TSC" on Android and Linux.
+        uint64_t high_performance_epoch_ms()
+        {
+            struct timespec ts;
+            clock_gettime(CLOCK_REALTIME_COARSE, &ts);
+            uint64_t epoch_milliseconds = (uint64_t)(ts.tv_sec) * 1000 + (uint64_t)(ts.tv_nsec) / 1000000;
+            return epoch_milliseconds;
+        }
+
+        struct ___base_dir_initializer {
+            bq::string base_dir;
+            ___base_dir_initializer()
+            {
+                bq::array<char> tmp;
+                tmp.fill_uninitialized(1024);
+                while (getcwd(&tmp[0], (int32_t)tmp.size()) == NULL) {
+                    tmp.fill_uninitialized(1024);
+                }
+                base_dir = &tmp[0];
+            }
+        };
+        const bq::string& get_base_dir(bool is_sandbox)
+        {
+            (void)is_sandbox;
+            static ___base_dir_initializer base_dir_init_inst;
+            return base_dir_init_inst.base_dir;
+        }
+
+        bool share_file(const char* file_path)
+        {
+            (void)file_path;
+            return false;
+        }
+    }
+}
+#endif

--- a/src/bq_common/platform/unix_misc.h
+++ b/src/bq_common/platform/unix_misc.h
@@ -10,23 +10,13 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  */
-
-//
-//  assert.h
-//  ensure assert take place even in release version
-
-//  Created by Yu Cao on 2022/9/17.
-//
-
-#ifdef NDEBUG
-#undef NDEBUG
-#include <assert.h>
-#define NDEBUG
-#else
-#include <assert.h>
-#endif
-
-// The BSDs and some other platforms predefine this, causing build conflicts
-#ifdef _assert
-#undef _assert
+#if BQ_UNIX
+#include <errno.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <pwd.h>
+#include "bq_common/platform/macros.h"
+#include "bq_common/types/array.h"
+#include "bq_common/types/string.h"
 #endif

--- a/src/bq_log/api/bq_log_api.cpp
+++ b/src/bq_log/api/bq_log_api.cpp
@@ -33,6 +33,17 @@
 #include <sys/syscall.h>
 #include <pthread.h>
 
+// The BSDs don't define these so define them as their equivalents
+#if !defined(BQ_APPLE) && !defined(BQ_PS) && defined(BQ_UNIX)
+#ifndef __NR_tgkill
+#define __NR_tgkill SYS_thr_kill
+#endif
+
+#ifndef __NR_gettid
+#define __NR_gettid SYS_getgid
+#endif
+#endif
+
 #if BQ_APPLE
 pid_t bq_gettid()
 {


### PR DESCRIPTION
Even though this work was primarily done to get your library to compile and build on FreeBSD 14.0 with Clang 17, this should compile without too many issues on the other BSDs and possibly a few other Unix systems.

Attached is a log from the demo showing that it ran successfully.

To get the demo to build properly, run the following from the root directory:

```
cd build/demo/linux
bash GenerateExecutable_Clang.sh
../../../artifacts/demo/linux/RelWithDebInfo/BqLogDemo
```
[BqLogDemo-Freebsd.log](https://github.com/user-attachments/files/16893543/BqLogDemo-Freebsd.log)
