### PR TITLE
Fix Linux may not have mmap enabled

### DIFF
--- a/src/bq_common/platform/io/memory_map_posix.cpp
+++ b/src/bq_common/platform/io/memory_map_posix.cpp
@@ -64,7 +64,7 @@ namespace bq {
             }
         }
 
-        result.real_data_ = mmap(NULL, real_mapping_size, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, real_mapping_offset);
+        result.real_data_ = mmap(NULL, real_mapping_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, real_mapping_offset);
 
         if (MAP_FAILED == result.real_data_) {
             result.error_code_ = errno;


### PR DESCRIPTION
MAP_PRIVATE
Create a private copy-on-write mapping. Updates to the
mapping are not visible to other processes mapping the
same file, and are not carried through to the underlying
file. It is unspecified whether changes made to the file
after the mmap() call are visible in the mapped region.